### PR TITLE
Fix ZeRO offload config

### DIFF
--- a/deepspeed_configs/ds_config_zero2.json
+++ b/deepspeed_configs/ds_config_zero2.json
@@ -28,6 +28,7 @@
   },
 
   "zero_allow_untested_optimizer": true,
+  "zero_force_ds_cpu_optimizer": false,
 
   "gradient_accumulation_steps": "auto",
   "gradient_clipping": "auto",

--- a/examples/pytorch/t0-zero-shot/run_t0.py
+++ b/examples/pytorch/t0-zero-shot/run_t0.py
@@ -9,6 +9,16 @@ import sys
 sys.path.insert(2, "./")
 
 import datasets
+try:
+    load_metric = datasets.load_metric
+except AttributeError:  # `load_metric` was removed in newer `datasets` versions
+    try:
+        import evaluate
+
+        load_metric = evaluate.load
+    except Exception as e:  # pragma: no cover - handle missing evaluate
+        raise ImportError(
+            "Neither `datasets.load_metric` nor `evaluate.load` are available" ) from e
 import transformers
 from transformers import (
     AutoConfig,
@@ -164,9 +174,9 @@ def main():
 
     config.num_choices = test_data.num_choices
     if test_args.metric_name == "none":
-        metrics = datasets.load_metric(data_args.dataset_name, data_args.subset_name, cache_dir=model_args.cache_dir)
+        metrics = load_metric(data_args.dataset_name, data_args.subset_name, cache_dir=model_args.cache_dir)
     else:
-        metrics = datasets.load_metric(test_args.metric_name, cache_dir=model_args.cache_dir)
+        metrics = load_metric(test_args.metric_name, cache_dir=model_args.cache_dir)
 
     logger.info(f"Model parameters {config}")
 
@@ -192,6 +202,10 @@ def main():
                 p.requires_grad = True
             else:
                 p.requires_grad = False
+        # ensure parameters are contiguous for deepspeed broadcast
+        for p in model.parameters():
+            if not p.data.is_contiguous():
+                p.data = p.data.contiguous()
         return model
 
     if test_args.test_mode == "t0":


### PR DESCRIPTION
## Summary
- allow ZeRO offload to use custom optimizer

## Testing
- `pytest tests/test_activations.py::TestActivations::test_gelu_versions -q` *(fails: PackageNotFoundError: No package metadata was found for tqdm)*

------
https://chatgpt.com/codex/tasks/task_e_6856299d4e1c83338fa6709739c131dd