### PR TITLE
Configure checkpoint saving in local DS script

### DIFF
--- a/exps_ttt/run_deepspeed_local.sh
+++ b/exps_ttt/run_deepspeed_local.sh
@@ -81,6 +81,9 @@ max_dev_size=1000
 temp=1.0
 copt="uniform"
 
+# Save checkpoints every 10 steps and keep only the most recent 10
+save_steps=10
+
 test_mode="ttt_t0"
 train_data="validation"
 train_size=10000
@@ -123,7 +126,8 @@ deepspeed --num_gpus 7 "$REPO_ROOT/examples/pytorch/t0-zero-shot/run_t0.py" \
   --lora_dropout ${lora_dropout} --lora_alpha ${lora_alpha} --lora_pos ${lora_pos} \
   --prob_temperature ${temp} --combine_option ${copt} \
   --train_random_n_prompts ${nprompts} --train_data_source ${train_data} \
-  --save_strategy 'steps' --warmup_steps 100 --gradient_accumulation_steps ${ga} \
+  --save_strategy 'steps' --save_steps ${save_steps} --save_total_limit 10 \
+  --warmup_steps 100 --gradient_accumulation_steps ${ga} \
   --lr_scheduler_type ${lr_scheduler_type} \
   --output_dir ${SAVE} --overwrite_output_dir --report_to "wandb" \
   --bf16 \


### PR DESCRIPTION
## Summary
- tweak `run_deepspeed_local.sh` to save checkpoints every 10 steps
- keep the latest 10 checkpoints

## Testing
- `make test` *(fails: PackageNotFoundError for tqdm)*

------
https://chatgpt.com/codex/tasks/task_e_6859fb9e2a448333a40e1ff53ccce9d9