### PR TITLE
Add example notebook for checkpoint generation

### DIFF
--- a/notebooks/check_checkpoint_generation.ipynb
+++ b/notebooks/check_checkpoint_generation.ipynb
@@ -1,0 +1,50 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Checkpoint Text Generation\n\nThis notebook loads a model checkpoint from the `checkpoints` directory and runs a few generation examples using Hugging Face's `text-generation` pipeline."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import sys\nfrom pathlib import Path\nsys.path.append(str(Path('..') / 'src'))  # use repo version of transformers\n\nfrom transformers import AutoTokenizer, AutoModelForCausalLM, pipeline\nimport torch"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "checkpoint_dir = 'checkpoints/checkpoint-10'  # adjust if needed"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "tokenizer = AutoTokenizer.from_pretrained(checkpoint_dir)\nmodel = AutoModelForCausalLM.from_pretrained(checkpoint_dir)\ngenerator = pipeline('text-generation', model=model, tokenizer=tokenizer,\n                     device=0 if torch.cuda.is_available() else -1)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "prompt = 'Hello, how are you today?'\noutputs = generator(prompt, max_length=50, num_return_sequences=1)\nprint(outputs[0]['generated_text'])"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary
- add a Jupyter notebook that loads a checkpoint
- run the Hugging Face text-generation pipeline on a sample prompt

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6859fe61fb448333ae37da38978451d9