### PR TITLE
Add ANLI R1 config to local deepspeed script

### DIFF
--- a/exps_ttt/run_deepspeed_local.sh
+++ b/exps_ttt/run_deepspeed_local.sh
@@ -36,7 +36,7 @@ export TOKENIZERS_PARALLELISM="false"
 DATE=`date +%Y%m%d`
 
 # Choose dataset name here, e.g., rte, cb, anli_r1 ...
-dname="rte"
+dname="anli_r1"
 
 datasets=(wsc winogrande anli_r1 anli_r2 anli_r3 cb rte copa hellaswag story_cloze wic)
 
@@ -54,7 +54,10 @@ elif [ ${dname} = "cb" ]; then
   dataset="super_glue"
   subset="cb"
   testset_name="validation"
-# Add other datasets if needed
+elif [ ${dname} = "anli_r1" ]; then
+  dataset="anli"
+  subset="none"
+  testset_name="dev_r1"
 else
   echo "wrong dataset name!"
   exit


### PR DESCRIPTION
## Summary
- enable ANLI R1 by default in `run_deepspeed_local.sh`
- configure dataset settings for ANLI R1

## Testing
- `bash -n exps_ttt/run_deepspeed_local.sh`

------
https://chatgpt.com/codex/tasks/task_e_686c8298fbf48333b9c36e6963e96399