### PR TITLE
Fix evaluation metrics logging

### DIFF
--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -358,13 +358,21 @@ def rewrite_logs(d):
     new_d = {}
     eval_prefix = "eval_"
     eval_prefix_len = len(eval_prefix)
+    unsup_prefix = "unsupervised_dev_"
+    unsup_prefix_len = len(unsup_prefix)
     test_prefix = "test_"
     test_prefix_len = len(test_prefix)
+    train_prefix = "train_"
+    train_prefix_len = len(train_prefix)
     for k, v in d.items():
         if k.startswith(eval_prefix):
             new_d["eval/" + k[eval_prefix_len:]] = v
+        elif k.startswith(unsup_prefix):
+            new_d["eval/" + k] = v
         elif k.startswith(test_prefix):
             new_d["test/" + k[test_prefix_len:]] = v
+        elif k.startswith(train_prefix):
+            new_d["train/" + k[train_prefix_len:]] = v
         else:
             new_d["train/" + k] = v
     return new_d


### PR DESCRIPTION
## Summary
- ensure unsupervised metrics aren't logged under the train section
- fix early stopping logic for prefixed metrics
- fix dataloader selection when logging train metrics

## Testing
- `black src/transformers/trainer.py src/transformers/integrations.py`
- `pytest -q` *(fails: PackageNotFoundError for tqdm)*

------
https://chatgpt.com/codex/tasks/task_e_686d5ae3e5548333abd402cc9a72b3d7