### PR TITLE
Fix wandb and early stopping

### DIFF
--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -498,7 +498,17 @@ class WandbCallback(TrainerCallback):
         if self._wandb is None:
             return
         self._initialized = True
-        if state.is_world_process_zero:
+
+        actual_world_process_zero = state.is_world_process_zero
+        try:
+            import torch
+
+            if torch.distributed.is_available() and torch.distributed.is_initialized():
+                actual_world_process_zero = torch.distributed.get_rank() == 0
+        except Exception:
+            pass
+
+        if actual_world_process_zero:
             logger.info(
                 'Automatic Weights & Biases logging enabled, to disable set os.environ["WANDB_DISABLED"] = "true"'
             )

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2150,11 +2150,16 @@ class Trainer:
                 eval_dataset=self.dev_dataset, metric_key_prefix="unsupervised_dev", ignore_keys=ignore_keys_for_eval
             )
 
-            if self.early_stop_metric > metrics["avg entropy"] and self.state.global_step > self.args.min_train_steps:
-                self.early_stop_patience = self.early_stop_patience + 1
-            else:
-                self.early_stop_patience = 0
-            self.early_stop_metric = metrics["avg entropy"]
+            metric_name = "unsupervised_dev_avg entropy"
+            if metric_name in metrics:
+                if (
+                    self.early_stop_metric > metrics[metric_name]
+                    and self.state.global_step > self.args.min_train_steps
+                ):
+                    self.early_stop_patience = self.early_stop_patience + 1
+                else:
+                    self.early_stop_patience = 0
+                self.early_stop_metric = metrics[metric_name]
 
             self._report_to_hp_search(trial, epoch, metrics)
 


### PR DESCRIPTION
## Summary
- avoid initializing wandb on non‑zero ranks
- guard early stopping check with correct unsupervised dev metric name

## Testing
- `make fixup` *(fails: flake8 missing)*
- `pytest tests/test_utils.py::TestIsTensorboardAvailable -q` *(fails: PackageNotFoundError: No package metadata was found for tqdm)*

------
https://chatgpt.com/codex/tasks/task_e_68754c06a1c083338faa9a9215affa18