### PR TITLE
Fix wandb multi-run

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1260,6 +1260,11 @@ class Trainer:
         # Check if saved optimizer or scheduler states exist
         self._load_optimizer_and_scheduler(resume_from_checkpoint)
 
+        # After initializing distributed training, update process zero flags so
+        # callbacks like `WandbCallback` correctly know which rank should log
+        self.state.is_local_process_zero = self.is_local_process_zero()
+        self.state.is_world_process_zero = self.is_world_process_zero()
+
         # important: at this point:
         # self.model         is the Transformers Model
         # self.model_wrapped is DDP(Transformers Model), Deepspeed(Transformers Model), etc.


### PR DESCRIPTION
## Summary
- update trainer to set process zero flags immediately after distributed init so wandb only logs from rank zero

## Testing
- `make fixup` *(fails: flake8 not found)*
- `make test` *(fails: PackageNotFoundError: tqdm)*

------
https://chatgpt.com/codex/tasks/task_e_687551fbf4888333bdd7d81e8e3b2629